### PR TITLE
Result画面での論文ページへのリンク機能をgeek_developにマージ

### DIFF
--- a/api/static/css/style.css
+++ b/api/static/css/style.css
@@ -152,6 +152,20 @@ header {
     height: 50px; /* ロゴの高さを設定 */
 }
 
+.link_seman_logo img{
+    width: 100%;
+    height: auto;
+}
+
+.seman_logo_container{
+    border: 1px solid #fff;
+    background-color: #fff;
+}
+
+.seman_logo_container:hover{
+    border: 1px solid #3879D9;
+}
+
 .main_table {
     margin-bottom: 30px;
     margin-left: 60px;

--- a/api/static/css/style.css
+++ b/api/static/css/style.css
@@ -152,20 +152,6 @@ header {
     height: 50px; /* ロゴの高さを設定 */
 }
 
-.link_seman_logo img{
-    width: 100%;
-    height: auto;
-}
-
-.seman_logo_container{
-    border: 1px solid #fff;
-    background-color: #fff;
-}
-
-.seman_logo_container:hover{
-    border: 1px solid #3879D9;
-}
-
 .main_table {
     margin-bottom: 30px;
     margin-left: 60px;

--- a/api/templates/result.html
+++ b/api/templates/result.html
@@ -3,7 +3,6 @@
 <html lang="ja">
     <link rel="stylesheet" href="/static/css/style.css">
     <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons/css/academicons.min.css">
     <head>
         <title>情報工学先生</title>
         <meta charset="utf-8"/>
@@ -41,11 +40,7 @@
                     {% for paper in papers %}
                     <tr>
                         <td>
-                            {{ paper["title"] }}
-                            <a class="seman_logo_container" href='{{ paper["url"] }}'>
-                                <i class="ai ai-semantic-scholar ai-1x">Semantic Scholar</i>
-                                <!-- <img src="https://assets-global.website-files.com/605236bb767e9a5bb229c63c/605274dd4af9b0ca8ac84182_s2-logo.svg" loading="lazy" height="20" alt="Semantic Scholar" class="link_seman_logo"> -->
-                            </a>
+                            <a>{{ paper["title"] }}</a>
                         </td>
                         <td>
                             {{ paper["tldr"] }}

--- a/api/templates/result.html
+++ b/api/templates/result.html
@@ -3,6 +3,7 @@
 <html lang="ja">
     <link rel="stylesheet" href="/static/css/style.css">
     <link href="https://stackpath.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/jpswalsh/academicons/css/academicons.min.css">
     <head>
         <title>情報工学先生</title>
         <meta charset="utf-8"/>
@@ -40,7 +41,11 @@
                     {% for paper in papers %}
                     <tr>
                         <td>
-                            <a>{{ paper["title"] }}</a>
+                            {{ paper["title"] }}
+                            <a class="seman_logo_container" href='{{ paper["url"] }}'>
+                                <i class="ai ai-semantic-scholar ai-1x">Semantic Scholar</i>
+                                <!-- <img src="https://assets-global.website-files.com/605236bb767e9a5bb229c63c/605274dd4af9b0ca8ac84182_s2-logo.svg" loading="lazy" height="20" alt="Semantic Scholar" class="link_seman_logo"> -->
+                            </a>
                         </td>
                         <td>
                             {{ paper["tldr"] }}

--- a/data/call_meta_paper.py
+++ b/data/call_meta_paper.py
@@ -59,7 +59,7 @@ class PaperCaller:
     def get_paper_by_paperId(self, paperId)->dict:
         # 論文データ取得用のパラメータ設定
         endpoint = "https://api.semanticscholar.org/graph/v1/paper/batch"
-        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr", "url")
+        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr")
         params = {
             "fields": ','.join(fields)
         }
@@ -80,7 +80,7 @@ class PaperCaller:
     def get_papers_by_paperIds(self, paperIDs)->list:
         # 論文データ取得用のパラメータ設定
         endpoint = "https://api.semanticscholar.org/graph/v1/paper/batch"
-        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr", "url")
+        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr")
         params = {
             "fields": ','.join(fields)
         }

--- a/data/call_meta_paper.py
+++ b/data/call_meta_paper.py
@@ -59,7 +59,7 @@ class PaperCaller:
     def get_paper_by_paperId(self, paperId)->dict:
         # 論文データ取得用のパラメータ設定
         endpoint = "https://api.semanticscholar.org/graph/v1/paper/batch"
-        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr")
+        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr", "url")
         params = {
             "fields": ','.join(fields)
         }
@@ -80,7 +80,7 @@ class PaperCaller:
     def get_papers_by_paperIds(self, paperIDs)->list:
         # 論文データ取得用のパラメータ設定
         endpoint = "https://api.semanticscholar.org/graph/v1/paper/batch"
-        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr")
+        fields = ('title', 'year', 'citationCount', 'authors', "abstract", "tldr", "url")
         params = {
             "fields": ','.join(fields)
         }


### PR DESCRIPTION
## merge geek_develop from geek_urlの失敗のリカバリというか再マージというか
geek_urlで追加した機能
[URLを持ってくる機能](https://github.com/enpitut2023/IE_teacher/commit/50f7d8eb273a866ebb78593b41e33db53e5de4d9)
[リザルト画面でリンクを張る機能](https://github.com/enpitut2023/IE_teacher/commit/b41edc50db715c6c3df1d38570d1e99972b2c7f2)
を、geek_developに再マージしたコードです。

TooManyRequestsのエラーでResult画面は見えないと思いますが、コードを確認してください
